### PR TITLE
Fixes opener no dbus feature missing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2021"
 [dependencies]
 crossterm = { version = "0.27.0", features = ["event-stream"] }
 futures = "0.3.30"
-opener = "0.7.0"
+opener = { version = "0.7.0", default-features = false }
 ratatui = "0.26.0"
 trash = "4.1.1"


### PR DESCRIPTION
This fixes the following error when compiling on Ubuntu WSL2.
```
the package `wiper` depends on `opener`, with features: `dbus` but `opener` does not have these features.
 It has an optional dependency with that name, but that dependency uses the "dep:" syntax in the features table, so it does not have an implicit feature with that name.
```