### PR TITLE
Fix Duplicate Key Event Issue on Windows

### DIFF
--- a/src/events/handler.rs
+++ b/src/events/handler.rs
@@ -1,58 +1,45 @@
 use crate::app::{App, AppResult};
 use crate::fs::{DataStore, DataStoreKey};
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+
+macro_rules! handle_key_event {
+    ($app:expr, $key_event:expr, $($pattern:pat => $action:expr),+) => {
+        match $key_event {
+            $(
+                KeyEvent { code: $pattern, kind: KeyEventKind::Press, .. } => {
+                    $action;
+                }
+            )+
+            _ => {}
+        }
+    };
+}
 
 pub fn handle_key_events<S: DataStore<DataStoreKey>>(
     key_event: KeyEvent,
     app: &mut App<S>,
 ) -> AppResult<()> {
-    match key_event.code {
-        KeyCode::Esc => {
-            app.on_escape();
-        }
-        KeyCode::Char('q') => {
-            app.quit();
-        }
-        KeyCode::Up | KeyCode::Char('k') => {
-            app.on_cursor_up();
-        }
-        KeyCode::Down | KeyCode::Char('j') => {
-            app.on_cursor_down();
-        }
-        KeyCode::Enter | KeyCode::Right | KeyCode::Char('l') => {
-            app.on_enter();
-        }
-        KeyCode::Backspace | KeyCode::Left | KeyCode::Char('h') => {
-            app.on_backspace();
-        }
-        // Exit application on `Ctrl-C`
+    handle_key_event!(
+        app,
+        key_event,
+        KeyCode::Enter     | KeyCode::Right | KeyCode::Char('l') => app.on_enter(),
+        KeyCode::Backspace | KeyCode::Left  | KeyCode::Char('h') => app.on_backspace(),
+        KeyCode::Up   | KeyCode::Char('k') => app.on_cursor_up(),
+        KeyCode::Down | KeyCode::Char('j') => app.on_cursor_down(),
+        KeyCode::Esc       => app.on_escape(),
+        KeyCode::Char('t') => app.on_toggle_move_to_trash(),
+        KeyCode::Char('q') => app.quit(),
+        KeyCode::Char('s') => app.on_toggle_sorting(),
+        KeyCode::Char('e') => app.on_open_file_explorer(),
+        KeyCode::Char('r') => app.reset(),
         KeyCode::Char('c') | KeyCode::Char('C') => {
-            if key_event.modifiers == KeyModifiers::CONTROL {
-                app.quit();
-            } else {
-                app.on_toggle_coloring();
-            }
-        }
-        KeyCode::Char('s') => {
-            app.on_toggle_sorting();
-        }
-        KeyCode::Char('e') => {
-            app.on_open_file_explorer();
-        }
-        KeyCode::Char('r') => {
-            app.reset();
-        }
+            if key_event.modifiers == KeyModifiers::CONTROL {app.quit()} 
+            else { app.on_toggle_coloring()}
+        },
         KeyCode::Char('d') => {
-            if key_event.modifiers == KeyModifiers::CONTROL {
-                app.toggle_debug();
-            } else {
-                app.on_delete();
-            }
+            if key_event.modifiers == KeyModifiers::CONTROL {app.toggle_debug()} 
+            else {app.on_delete()}
         }
-        KeyCode::Char('t') => {
-            app.on_toggle_move_to_trash();
-        }
-        _ => {}
-    }
+    );
     Ok(())
 }


### PR DESCRIPTION
This pull request resolves the issue of the same key being sent twice to the keyboard event handler on Windows, as demonstrated in the video.

https://github.com/user-attachments/assets/0c816cbe-92e4-4a55-90d8-47c005b71a16

To avoid this issue, an eventkind check was added so that the handler only accepts key press events. This fixes the problem on Windows, as shown in the video.

https://github.com/user-attachments/assets/0b6d2dd4-9c64-4594-8c17-147ac0e55c52

This change does not affect the behavior in environments that do not use KeyEventKind, as crossterm defaults that all key event types are press events.